### PR TITLE
fix nasty undo redo crash

### DIFF
--- a/library/tulip-core/src/GraphStorage.cpp
+++ b/library/tulip-core/src/GraphStorage.cpp
@@ -410,6 +410,8 @@ void GraphStorage::swapEdgeOrder(const node n, const edge e1, const edge e2) {
  * @brief restore the given node in the structure and return it
  */
 void GraphStorage::restoreNode(const node n) {
+  if (n.id == nodeData.size())
+    nodeData.resize(n.id + 1);
   NodeData& nData = nodeData[n.id];
   // clear edge infos
   nData.edges.clear();
@@ -424,12 +426,7 @@ void GraphStorage::restoreNode(const node n) {
  */
 node GraphStorage::addNode() {
   node n(nodeIds.get());
-
-  if (n.id == nodeData.size())
-    nodeData.resize(n.id + 1);
-  else
-    restoreNode(n);
-
+  restoreNode(n);
   return n;
 }
 //=======================================================


### PR DESCRIPTION
Fix segfault in Tulip 5.0 when one deletes all nodes of a graph and trying to restore them with a redo operation