### PR TITLE
Make it pass desktop-file-validate

### DIFF
--- a/bundlers/linux/make_appimage_bundle.sh.in
+++ b/bundlers/linux/make_appimage_bundle.sh.in
@@ -71,10 +71,11 @@ chmod 755 $APPRUN_FILE
 DESKTOP_FILE=$BUNDLE_DIR/tulip.desktop
 echo "[Desktop Entry]" > $DESKTOP_FILE
 echo "Name=Tulip" >> $DESKTOP_FILE
-echo "Version=@TulipVersion@" >> $DESKTOP_FILE
+echo "X-Tulip-Version=@TulipVersion@" >> $DESKTOP_FILE
 echo "Type=Application" >> $DESKTOP_FILE
 echo "Exec=tulip_perspective" >> $DESKTOP_FILE
 echo "Icon=Tulip" >> $DESKTOP_FILE
+echo "Categories=Graphics;" >> $DESKTOP_FILE
 
 # copy Tulip.png
 cp @tulip_SOURCE_DIR@/bundlers/linux/Tulip.png $BUNDLE_DIR


### PR DESCRIPTION
Reference: https://travis-ci.org/AppImage/AppImageHub/builds/266251154#L544

`Version=` is __not__ for the version of the application, according to the XDG desktop spec.